### PR TITLE
MySQLのバージョンを5.7に固定

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,18 @@ $ docker-compose exec workspace bash
 
 変更前：
 ```
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 ```
 変更後：
 ```
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
 DB_DATABASE=study_laravel
 DB_USERNAME=study_laravel
 DB_PASSWORD=study_laravel

--- a/scripts/config/.laradock-env
+++ b/scripts/config/.laradock-env
@@ -184,7 +184,7 @@ APACHE_DOCUMENT_ROOT=/var/www/
 
 ### MYSQL #################################################
 
-MYSQL_VERSION=latest
+MYSQL_VERSION=5.7
 MYSQL_DATABASE=study_laravel
 MYSQL_USER=study_laravel
 MYSQL_PASSWORD=study_laravel


### PR DESCRIPTION
- MySQLのバージョンを5.7に固定
    - 8だと色々と面倒臭い
    - https://qiita.com/hondy12345/items/60a91488648f5ff45ff9
- README修正
    - DB_HOSTを`mysql`にする必要があった